### PR TITLE
[PKG-2080] ordered-set 4.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,32 +10,37 @@ source:
   sha256: 694a8e44c87657c59292ede72891eb91d34131f6531463aab3009191c77364a8
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
+    - flit-core 3.8.0
     - pip
-    - python >=3.7
-    - flit-core
+    - python
+    - wheel
   run:
-    - python >=3.7
+    - python
 
 test:
   imports:
     - ordered_set
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
-  home: http://github.com/LuminosoInsight/ordered-set
+  home: https://github.com/rspeer/ordered-set
+  dev_url: https://github.com/rspeer/ordered-set
+  doc_url: https://github.com/rspeer/ordered-set
   license: MIT
+  license_family: MIT
   license_file: MIT-LICENSE
   summary: A MutableSet that remembers its order, so that every entry has an index.
-
+  description: |
+    An OrderedSet is a mutable data structure that is a hybrid of a list and a set. It remembers the order of its entries, and every entry has an index number that can be looked up.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
License: https://github.com/rspeer/ordered-set/blob/release/4.1.0/MIT-LICENSE
Requirements:
- https://github.com/rspeer/ordered-set/blob/release/4.1.0/pyproject.toml
- https://github.com/rspeer/ordered-set/blob/release/4.1.0/setup.py

Actions:
1. Skip `py<37`
2. Add `--no-deps --no-build-isolation` to `script`
3. Add `wheel` to `host` and pin `flit-core` to `3.8.0`
4. Update `home` url
5. Add dev & doc urls
6. Add `license_family`
7. Add `description`

Notes:
- `nuitka 1.5.7` requires it https://github.com/AnacondaRecipes/nuitka-feedstock/pull/32